### PR TITLE
Add partials scaffolding for drupaltools-best-practices (SKILL stubs and READMEs)

### DIFF
--- a/skills/drupaltools-best-practices/SKILL.md
+++ b/skills/drupaltools-best-practices/SKILL.md
@@ -142,3 +142,16 @@ If everything passes: write a short paragraph summarising what is correct and wh
 - Drupal-spec-tool (automated testing): https://github.com/acquia/drupal-spec-tool
 - Composer best practices: https://www.lullabot.com/articles/drupal-8-composer-best-practices
 - Module incompatibilities (Acquia): https://docs.acquia.com/acquia-cloud/develop/drupal/module-incompatibilities
+
+## Partials
+
+- `partials/blocks/SKILL.md`
+- `partials/config-parser/SKILL.md`
+- `partials/fields/SKILL.md`
+- `partials/forms/SKILL.md`
+- `partials/nodes/SKILL.md`
+- `partials/other-content-entities/SKILL.md`
+- `partials/taxonomy/SKILL.md`
+- `partials/text-formats-editors/SKILL.md`
+- `partials/theming/SKILL.md`
+- `partials/views/SKILL.md`

--- a/skills/drupaltools-best-practices/SKILL.md
+++ b/skills/drupaltools-best-practices/SKILL.md
@@ -145,13 +145,13 @@ If everything passes: write a short paragraph summarising what is correct and wh
 
 ## Partials
 
-- `partials/blocks/SKILL.md`
-- `partials/config-parser/SKILL.md`
-- `partials/fields/SKILL.md`
-- `partials/forms/SKILL.md`
-- `partials/nodes/SKILL.md`
-- `partials/other-content-entities/SKILL.md`
-- `partials/taxonomy/SKILL.md`
-- `partials/text-formats-editors/SKILL.md`
-- `partials/theming/SKILL.md`
-- `partials/views/SKILL.md`
+- `partials/blocks/SKILL.md` (partial sub-skill)
+- `partials/config-parser/SKILL.md` (partial sub-skill)
+- `partials/fields/SKILL.md` (partial sub-skill)
+- `partials/forms/SKILL.md` (partial sub-skill)
+- `partials/nodes/SKILL.md` (partial sub-skill)
+- `partials/other-content-entities/SKILL.md` (partial sub-skill)
+- `partials/taxonomy/SKILL.md` (partial sub-skill)
+- `partials/text-formats-editors/SKILL.md` (partial sub-skill)
+- `partials/theming/SKILL.md` (partial sub-skill)
+- `partials/views/SKILL.md` (partial sub-skill)

--- a/skills/drupaltools-best-practices/partials/README.md
+++ b/skills/drupaltools-best-practices/partials/README.md
@@ -1,0 +1,27 @@
+# Partials for drupaltools-best-practices
+
+This folder maps to the upstream `ai/skills` structure from:
+`theodorosploumis/drupal-best-practices`.
+
+## Mapped sub-skills
+- `blocks/`
+- `config-parser/`
+- `fields/`
+- `forms/`
+- `nodes/`
+- `other-content-entities/`
+- `taxonomy/`
+- `text-formats-editors/`
+- `theming/`
+- `views/`
+
+## Expected per-sub-skill layout
+Each sub-skill now includes:
+- `SKILL.md`
+- `examples/example-01.md`
+- `references/README.md`
+- `scripts/README.md`
+
+Notes:
+- Content is mapped from the existing local `drupaltools-best-practices` guidance.
+- `claude-code-skills.md` is a root document upstream and is not represented as a sub-skill folder.

--- a/skills/drupaltools-best-practices/partials/blocks/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/blocks/SKILL.md
@@ -1,3 +1,8 @@
-## Blocks checks
+---
+name: drupaltools-best-practices/blocks
+description: Partial sub-skill checks for blocks within drupaltools-best-practices.
+---
+
+# Blocks checks
 - Do not use nodes as dynamic blocks; use custom block types or entities.
 - Use real menu structures for navigation, not block-as-menu workarounds.

--- a/skills/drupaltools-best-practices/partials/blocks/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/blocks/SKILL.md
@@ -1,0 +1,3 @@
+## Blocks checks
+- Do not use nodes as dynamic blocks; use custom block types or entities.
+- Use real menu structures for navigation, not block-as-menu workarounds.

--- a/skills/drupaltools-best-practices/partials/blocks/examples/example-01.md
+++ b/skills/drupaltools-best-practices/partials/blocks/examples/example-01.md
@@ -1,0 +1,4 @@
+# Example — blocks
+
+Use this example file to add concrete audit inputs/outputs for:
+`partials/blocks/SKILL.md`

--- a/skills/drupaltools-best-practices/partials/blocks/references/README.md
+++ b/skills/drupaltools-best-practices/partials/blocks/references/README.md
@@ -1,0 +1,3 @@
+# References for blocks
+
+Store source links, standards notes, or extracted snippets relevant to this partial.

--- a/skills/drupaltools-best-practices/partials/blocks/scripts/README.md
+++ b/skills/drupaltools-best-practices/partials/blocks/scripts/README.md
@@ -1,0 +1,3 @@
+# Scripts for blocks
+
+Place helper scripts for automating checks tied to this partial.

--- a/skills/drupaltools-best-practices/partials/config-parser/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/config-parser/SKILL.md
@@ -1,0 +1,4 @@
+## Config parser checks
+- Validate machine names are singular and human-readable.
+- Ensure config naming avoids clashes with core/contrib names.
+- Flag views display suffixes like `_1` and non-generic image style names.

--- a/skills/drupaltools-best-practices/partials/config-parser/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/config-parser/SKILL.md
@@ -1,4 +1,9 @@
-## Config parser checks
+---
+name: drupaltools-best-practices/config-parser
+description: Partial sub-skill checks for config-parser within drupaltools-best-practices.
+---
+
+# Config parser checks
 - Validate machine names are singular and human-readable.
 - Ensure config naming avoids clashes with core/contrib names.
 - Flag views display suffixes like `_1` and non-generic image style names.

--- a/skills/drupaltools-best-practices/partials/config-parser/examples/example-01.md
+++ b/skills/drupaltools-best-practices/partials/config-parser/examples/example-01.md
@@ -1,0 +1,4 @@
+# Example — config-parser
+
+Use this example file to add concrete audit inputs/outputs for:
+`partials/config-parser/SKILL.md`

--- a/skills/drupaltools-best-practices/partials/config-parser/references/README.md
+++ b/skills/drupaltools-best-practices/partials/config-parser/references/README.md
@@ -1,0 +1,3 @@
+# References for config-parser
+
+Store source links, standards notes, or extracted snippets relevant to this partial.

--- a/skills/drupaltools-best-practices/partials/config-parser/scripts/README.md
+++ b/skills/drupaltools-best-practices/partials/config-parser/scripts/README.md
@@ -1,0 +1,3 @@
+# Scripts for config-parser
+
+Place helper scripts for automating checks tied to this partial.

--- a/skills/drupaltools-best-practices/partials/fields/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/fields/SKILL.md
@@ -1,4 +1,9 @@
-## Fields checks
+---
+name: drupaltools-best-practices/fields
+description: Partial sub-skill checks for fields within drupaltools-best-practices.
+---
+
+# Fields checks
 - Field names should follow Drupal conventions.
 - Each field should include a clear Description.
 - Image fields should use named directories; disable `gif` unless needed.

--- a/skills/drupaltools-best-practices/partials/fields/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/fields/SKILL.md
@@ -1,0 +1,4 @@
+## Fields checks
+- Field names should follow Drupal conventions.
+- Each field should include a clear Description.
+- Image fields should use named directories; disable `gif` unless needed.

--- a/skills/drupaltools-best-practices/partials/fields/examples/example-01.md
+++ b/skills/drupaltools-best-practices/partials/fields/examples/example-01.md
@@ -1,0 +1,4 @@
+# Example — fields
+
+Use this example file to add concrete audit inputs/outputs for:
+`partials/fields/SKILL.md`

--- a/skills/drupaltools-best-practices/partials/fields/references/README.md
+++ b/skills/drupaltools-best-practices/partials/fields/references/README.md
@@ -1,0 +1,3 @@
+# References for fields
+
+Store source links, standards notes, or extracted snippets relevant to this partial.

--- a/skills/drupaltools-best-practices/partials/fields/scripts/README.md
+++ b/skills/drupaltools-best-practices/partials/fields/scripts/README.md
@@ -1,0 +1,3 @@
+# Scripts for fields
+
+Place helper scripts for automating checks tied to this partial.

--- a/skills/drupaltools-best-practices/partials/forms/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/forms/SKILL.md
@@ -1,0 +1,4 @@
+## Forms checks
+- Permission titles should start with verbs (View/Administer/Delete).
+- Ensure access is permission-based rather than role-based where applicable.
+- Avoid exposing insecure edit pathways via form configuration.

--- a/skills/drupaltools-best-practices/partials/forms/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/forms/SKILL.md
@@ -1,4 +1,9 @@
-## Forms checks
+---
+name: drupaltools-best-practices/forms
+description: Partial sub-skill checks for forms within drupaltools-best-practices.
+---
+
+# Forms checks
 - Permission titles should start with verbs (View/Administer/Delete).
 - Ensure access is permission-based rather than role-based where applicable.
 - Avoid exposing insecure edit pathways via form configuration.

--- a/skills/drupaltools-best-practices/partials/forms/examples/example-01.md
+++ b/skills/drupaltools-best-practices/partials/forms/examples/example-01.md
@@ -1,0 +1,4 @@
+# Example — forms
+
+Use this example file to add concrete audit inputs/outputs for:
+`partials/forms/SKILL.md`

--- a/skills/drupaltools-best-practices/partials/forms/references/README.md
+++ b/skills/drupaltools-best-practices/partials/forms/references/README.md
@@ -1,0 +1,3 @@
+# References for forms
+
+Store source links, standards notes, or extracted snippets relevant to this partial.

--- a/skills/drupaltools-best-practices/partials/forms/scripts/README.md
+++ b/skills/drupaltools-best-practices/partials/forms/scripts/README.md
@@ -1,0 +1,3 @@
+# Scripts for forms
+
+Place helper scripts for automating checks tied to this partial.

--- a/skills/drupaltools-best-practices/partials/nodes/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/nodes/SKILL.md
@@ -1,4 +1,9 @@
-## Nodes checks
+---
+name: drupaltools-best-practices/nodes
+description: Partial sub-skill checks for nodes within drupaltools-best-practices.
+---
+
+# Nodes checks
 - Revisions should not be globally enabled unless workflow requires them.
 - Bundle machine names should be singular and descriptive.
 - Avoid overloading nodes for non-node content behavior.

--- a/skills/drupaltools-best-practices/partials/nodes/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/nodes/SKILL.md
@@ -1,0 +1,4 @@
+## Nodes checks
+- Revisions should not be globally enabled unless workflow requires them.
+- Bundle machine names should be singular and descriptive.
+- Avoid overloading nodes for non-node content behavior.

--- a/skills/drupaltools-best-practices/partials/nodes/examples/example-01.md
+++ b/skills/drupaltools-best-practices/partials/nodes/examples/example-01.md
@@ -1,0 +1,4 @@
+# Example — nodes
+
+Use this example file to add concrete audit inputs/outputs for:
+`partials/nodes/SKILL.md`

--- a/skills/drupaltools-best-practices/partials/nodes/references/README.md
+++ b/skills/drupaltools-best-practices/partials/nodes/references/README.md
@@ -1,0 +1,3 @@
+# References for nodes
+
+Store source links, standards notes, or extracted snippets relevant to this partial.

--- a/skills/drupaltools-best-practices/partials/nodes/scripts/README.md
+++ b/skills/drupaltools-best-practices/partials/nodes/scripts/README.md
@@ -1,0 +1,3 @@
+# Scripts for nodes
+
+Place helper scripts for automating checks tied to this partial.

--- a/skills/drupaltools-best-practices/partials/other-content-entities/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/other-content-entities/SKILL.md
@@ -1,0 +1,4 @@
+## Other content entities checks
+- Use fit-for-purpose entities instead of misusing node or taxonomy patterns.
+- Keep machine names generic and maintainable.
+- Apply docblocks and coding standards for custom entity code.

--- a/skills/drupaltools-best-practices/partials/other-content-entities/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/other-content-entities/SKILL.md
@@ -1,4 +1,9 @@
-## Other content entities checks
+---
+name: drupaltools-best-practices/other-content-entities
+description: Partial sub-skill checks for other-content-entities within drupaltools-best-practices.
+---
+
+# Other content entities checks
 - Use fit-for-purpose entities instead of misusing node or taxonomy patterns.
 - Keep machine names generic and maintainable.
 - Apply docblocks and coding standards for custom entity code.

--- a/skills/drupaltools-best-practices/partials/other-content-entities/examples/example-01.md
+++ b/skills/drupaltools-best-practices/partials/other-content-entities/examples/example-01.md
@@ -1,0 +1,4 @@
+# Example — other-content-entities
+
+Use this example file to add concrete audit inputs/outputs for:
+`partials/other-content-entities/SKILL.md`

--- a/skills/drupaltools-best-practices/partials/other-content-entities/references/README.md
+++ b/skills/drupaltools-best-practices/partials/other-content-entities/references/README.md
@@ -1,0 +1,3 @@
+# References for other-content-entities
+
+Store source links, standards notes, or extracted snippets relevant to this partial.

--- a/skills/drupaltools-best-practices/partials/other-content-entities/scripts/README.md
+++ b/skills/drupaltools-best-practices/partials/other-content-entities/scripts/README.md
@@ -1,0 +1,3 @@
+# Scripts for other-content-entities
+
+Place helper scripts for automating checks tied to this partial.

--- a/skills/drupaltools-best-practices/partials/taxonomy/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/taxonomy/SKILL.md
@@ -1,0 +1,4 @@
+## Taxonomy checks
+- Use taxonomy terms only where categorized pages or true vocabularies are required.
+- Avoid taxonomy-only solutions for simple filtering when better patterns exist.
+- Taxonomy-related field machine names should remain explicit and readable.

--- a/skills/drupaltools-best-practices/partials/taxonomy/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/taxonomy/SKILL.md
@@ -1,4 +1,9 @@
-## Taxonomy checks
+---
+name: drupaltools-best-practices/taxonomy
+description: Partial sub-skill checks for taxonomy within drupaltools-best-practices.
+---
+
+# Taxonomy checks
 - Use taxonomy terms only where categorized pages or true vocabularies are required.
 - Avoid taxonomy-only solutions for simple filtering when better patterns exist.
 - Taxonomy-related field machine names should remain explicit and readable.

--- a/skills/drupaltools-best-practices/partials/taxonomy/examples/example-01.md
+++ b/skills/drupaltools-best-practices/partials/taxonomy/examples/example-01.md
@@ -1,0 +1,4 @@
+# Example — taxonomy
+
+Use this example file to add concrete audit inputs/outputs for:
+`partials/taxonomy/SKILL.md`

--- a/skills/drupaltools-best-practices/partials/taxonomy/references/README.md
+++ b/skills/drupaltools-best-practices/partials/taxonomy/references/README.md
@@ -1,0 +1,3 @@
+# References for taxonomy
+
+Store source links, standards notes, or extracted snippets relevant to this partial.

--- a/skills/drupaltools-best-practices/partials/taxonomy/scripts/README.md
+++ b/skills/drupaltools-best-practices/partials/taxonomy/scripts/README.md
@@ -1,0 +1,3 @@
+# Scripts for taxonomy
+
+Place helper scripts for automating checks tied to this partial.

--- a/skills/drupaltools-best-practices/partials/text-formats-editors/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/text-formats-editors/SKILL.md
@@ -1,4 +1,9 @@
-## Text formats and editors checks
+---
+name: drupaltools-best-practices/text-formats-editors
+description: Partial sub-skill checks for text-formats-editors within drupaltools-best-practices.
+---
+
+# Text formats and editors checks
 - Keep one HTML-allowed text format where possible.
 - CKEditor buttons must match allowed HTML tags.
 - Never allow PHP in WYSIWYG content.

--- a/skills/drupaltools-best-practices/partials/text-formats-editors/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/text-formats-editors/SKILL.md
@@ -1,0 +1,4 @@
+## Text formats and editors checks
+- Keep one HTML-allowed text format where possible.
+- CKEditor buttons must match allowed HTML tags.
+- Never allow PHP in WYSIWYG content.

--- a/skills/drupaltools-best-practices/partials/text-formats-editors/examples/example-01.md
+++ b/skills/drupaltools-best-practices/partials/text-formats-editors/examples/example-01.md
@@ -1,0 +1,4 @@
+# Example — text-formats-editors
+
+Use this example file to add concrete audit inputs/outputs for:
+`partials/text-formats-editors/SKILL.md`

--- a/skills/drupaltools-best-practices/partials/text-formats-editors/references/README.md
+++ b/skills/drupaltools-best-practices/partials/text-formats-editors/references/README.md
@@ -1,0 +1,3 @@
+# References for text-formats-editors
+
+Store source links, standards notes, or extracted snippets relevant to this partial.

--- a/skills/drupaltools-best-practices/partials/text-formats-editors/scripts/README.md
+++ b/skills/drupaltools-best-practices/partials/text-formats-editors/scripts/README.md
@@ -1,0 +1,3 @@
+# Scripts for text-formats-editors
+
+Place helper scripts for automating checks tied to this partial.

--- a/skills/drupaltools-best-practices/partials/theming/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/theming/SKILL.md
@@ -1,0 +1,4 @@
+## Theming checks
+- Use one base theme and independent subtheme naming.
+- Put logic in preprocess functions, not inline Twig complexity.
+- Use semantic classes and organized template override structure.

--- a/skills/drupaltools-best-practices/partials/theming/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/theming/SKILL.md
@@ -1,4 +1,9 @@
-## Theming checks
+---
+name: drupaltools-best-practices/theming
+description: Partial sub-skill checks for theming within drupaltools-best-practices.
+---
+
+# Theming checks
 - Use one base theme and independent subtheme naming.
 - Put logic in preprocess functions, not inline Twig complexity.
 - Use semantic classes and organized template override structure.

--- a/skills/drupaltools-best-practices/partials/theming/examples/example-01.md
+++ b/skills/drupaltools-best-practices/partials/theming/examples/example-01.md
@@ -1,0 +1,4 @@
+# Example — theming
+
+Use this example file to add concrete audit inputs/outputs for:
+`partials/theming/SKILL.md`

--- a/skills/drupaltools-best-practices/partials/theming/references/README.md
+++ b/skills/drupaltools-best-practices/partials/theming/references/README.md
@@ -1,0 +1,3 @@
+# References for theming
+
+Store source links, standards notes, or extracted snippets relevant to this partial.

--- a/skills/drupaltools-best-practices/partials/theming/scripts/README.md
+++ b/skills/drupaltools-best-practices/partials/theming/scripts/README.md
@@ -1,0 +1,3 @@
+# Scripts for theming
+
+Place helper scripts for automating checks tied to this partial.

--- a/skills/drupaltools-best-practices/partials/views/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/views/SKILL.md
@@ -1,4 +1,9 @@
-## Views checks
+---
+name: drupaltools-best-practices/views
+description: Partial sub-skill checks for views within drupaltools-best-practices.
+---
+
+# Views checks
 - Prefer one display per View unless explicitly needed.
 - Use content mode over field-mode when possible.
 - Disable Ajax by default; provide No results text; use permission-based access.

--- a/skills/drupaltools-best-practices/partials/views/SKILL.md
+++ b/skills/drupaltools-best-practices/partials/views/SKILL.md
@@ -1,0 +1,4 @@
+## Views checks
+- Prefer one display per View unless explicitly needed.
+- Use content mode over field-mode when possible.
+- Disable Ajax by default; provide No results text; use permission-based access.

--- a/skills/drupaltools-best-practices/partials/views/examples/example-01.md
+++ b/skills/drupaltools-best-practices/partials/views/examples/example-01.md
@@ -1,0 +1,4 @@
+# Example — views
+
+Use this example file to add concrete audit inputs/outputs for:
+`partials/views/SKILL.md`

--- a/skills/drupaltools-best-practices/partials/views/references/README.md
+++ b/skills/drupaltools-best-practices/partials/views/references/README.md
@@ -1,0 +1,3 @@
+# References for views
+
+Store source links, standards notes, or extracted snippets relevant to this partial.

--- a/skills/drupaltools-best-practices/partials/views/scripts/README.md
+++ b/skills/drupaltools-best-practices/partials/views/scripts/README.md
@@ -1,0 +1,3 @@
+# Scripts for views
+
+Place helper scripts for automating checks tied to this partial.


### PR DESCRIPTION
### Motivation

- Split the existing guidance into mapped sub-skills to match the upstream `theodorosploumis/drupal-best-practices` structure and make audits more modular.
- Provide focused, per-area placeholders for checks, examples, references, and automation scripts to improve maintainability and onboarding for future enhancements.
- Enable incremental addition of automated checks and documentation per sub-skill instead of a single monolithic `SKILL.md`.

### Description

- Appended a `## Partials` section to `skills/drupaltools-best-practices/SKILL.md` listing the new partial paths. 
- Added `skills/drupaltools-best-practices/partials/README.md` describing the mapped sub-skills and the expected layout for each sub-skill. 
- Added scaffold folders and files for the following sub-skills: `blocks`, `config-parser`, `fields`, `forms`, `nodes`, `other-content-entities`, `taxonomy`, `text-formats-editors`, `theming`, and `views`, each containing `SKILL.md`, `examples/example-01.md`, `references/README.md`, and `scripts/README.md` as starter content. 

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0769aabed48326971bc42030e0bcc2)